### PR TITLE
handleState when state.kind is null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,7 +98,7 @@ class SourceMap {
       const pathName = this._path.join(".");
 
       // scalar typse are primitives (non maps/arrays)
-      if (kind === "scalar") {
+      if (kind === "scalar" || kind === null) {
         // we need to pop the path before computing things for scalars
         this._path.pop();
 


### PR DESCRIPTION
when a yaml file array property has item without a value  (which will cause a validation error) 
it was found that `state.kind` is reported as null causing the `handleState` method to skip this scalar type
in the example below `filename` doesn't have a value 
---
```
rootpath:
   - pathtype: type1
     filename: 
```
which `js-yaml` will report its` filename` json data as `null`
```
{
  rootpath: [
    {
      pathtype: "type1",
      filename: null,
    },
  ],
}
```
a fix (workaround) can be applied by adding `kind === null` condition to the `scalar types are primitives (non maps/arrays)` condition
```
// scalar types are primitives (non maps/arrays)
      if (kind === "scalar" || kind === null) {
            ........
      }
``` 
